### PR TITLE
Remove unused CORS origins

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -16,11 +16,7 @@ connectDb();
 
 app.use(
   cors({
-    origin: [
-      "https://blog-zone-web.netlify.app",
-      "http://localhost:5173",
-      "https://meta-blog-app.vercel.app",
-    ],
+    origin: ["https://meta-blog-app.vercel.app"],
     credentials: true,
   })
 );


### PR DESCRIPTION
This PR removes the unused CORS origins from the server configuration. The origin "https://meta-blog-app.vercel.app" is the only allowed origin now.